### PR TITLE
Prevent in-memory pagination in batch

### DIFF
--- a/src/main/java/no/nav/bidrag/aktoerregister/persistence/entities/Hendelse.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/persistence/entities/Hendelse.java
@@ -31,6 +31,10 @@ public class Hendelse {
   public Hendelse() {
   }
 
+  public Hendelse(Aktoer aktoer) {
+    this.aktoer = aktoer;
+  }
+
   public Hendelse(int sekvensnummer, Aktoer aktoer) {
     this.sekvensnummer = sekvensnummer;
     this.aktoer = aktoer;

--- a/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/AktoerJpaRepository.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/AktoerJpaRepository.java
@@ -3,11 +3,9 @@ package no.nav.bidrag.aktoerregister.persistence.repository;
 import no.nav.bidrag.aktoerregister.persistence.entities.Aktoer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AktoerJpaRepository extends JpaRepository<Aktoer, String> {
 
-  @EntityGraph(attributePaths = {"hendelser"})
   Page<Aktoer> findAllByAktoerType(String aktoerType, Pageable pageable);
 }

--- a/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/AktoerRepositoryImpl.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/AktoerRepositoryImpl.java
@@ -20,13 +20,12 @@ public class AktoerRepositoryImpl implements AktoerRepository {
 
   @Override
   public Aktoer insertOrUpdateAktoer(Aktoer aktoer) {
-    aktoer.addHendelse(createHendelse(aktoer));
+    aktoer.addHendelse(new Hendelse(aktoer));
     return aktoerJpaRepository.save(aktoer);
   }
 
   @Override
   public List<Aktoer> insertOrUpdateAktoerer(List<Aktoer> aktoerList) {
-    aktoerList.forEach(aktoer -> aktoer.addHendelse(createHendelse(aktoer)));
     return aktoerJpaRepository.saveAll(aktoerList);
   }
 
@@ -38,11 +37,5 @@ public class AktoerRepositoryImpl implements AktoerRepository {
   @Override
   public void deleteAktoer(String aktoerId) {
     aktoerJpaRepository.deleteById(aktoerId);
-  }
-
-  private Hendelse createHendelse(Aktoer aktoer) {
-    Hendelse hendelse = new Hendelse();
-    hendelse.setAktoer(aktoer);
-    return hendelse;
   }
 }

--- a/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/HendelseRepository.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/HendelseRepository.java
@@ -1,10 +1,12 @@
 package no.nav.bidrag.aktoerregister.persistence.repository;
 
 import java.util.List;
+import no.nav.bidrag.aktoerregister.persistence.entities.Aktoer;
 import no.nav.bidrag.aktoerregister.persistence.entities.Hendelse;
 
 public interface HendelseRepository {
 
   List<Hendelse> hentHendelser(int fraSekvensnummer, int antallHendelser);
 
+  void insertHendelser(List<Aktoer> updatedAktoerer);
 }

--- a/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/HendelseRepositoryImpl.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/persistence/repository/HendelseRepositoryImpl.java
@@ -1,6 +1,7 @@
 package no.nav.bidrag.aktoerregister.persistence.repository;
 
 import java.util.List;
+import no.nav.bidrag.aktoerregister.persistence.entities.Aktoer;
 import no.nav.bidrag.aktoerregister.persistence.entities.Hendelse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
@@ -24,5 +25,11 @@ public class HendelseRepositoryImpl implements HendelseRepository {
   @Override
   public List<Hendelse> hentHendelser(int fraSekvensnummer, int antallHendelser) {
     return hendelseJpaRepository.getHendelserWithUniqueAktoerPageable(fraSekvensnummer, Pageable.ofSize(antallHendelser));
+  }
+
+  @Override
+  public void insertHendelser(List<Aktoer> updatedAktoerer) {
+    List<Hendelse> hendelser = updatedAktoerer.stream().map(Hendelse::new).toList();
+    hendelseJpaRepository.saveAll(hendelser);
   }
 }

--- a/src/main/java/no/nav/bidrag/aktoerregister/service/AktoerregisterServiceImpl.java
+++ b/src/main/java/no/nav/bidrag/aktoerregister/service/AktoerregisterServiceImpl.java
@@ -106,6 +106,7 @@ public class AktoerregisterServiceImpl implements AktoerregisterService {
   public void oppdaterAktoerer(List<Aktoer> updatedAktoerList) {
     logger.info("Oppdaterer {} aktoerer", updatedAktoerList.size());
     aktoerRepository.insertOrUpdateAktoerer(updatedAktoerList);
+    hendelseRepository.insertHendelser(updatedAktoerList);
   }
 
   @Override

--- a/src/test/java/no/nav/bidrag/aktoerregister/repository/AktoerRepositoryTests.java
+++ b/src/test/java/no/nav/bidrag/aktoerregister/repository/AktoerRepositoryTests.java
@@ -4,8 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import no.nav.bidrag.aktoerregister.AktoerregisterApplication;
 import no.nav.bidrag.aktoerregister.domene.IdenttypeDTO;
 import no.nav.bidrag.aktoerregister.persistence.entities.Adresse;
@@ -101,21 +105,45 @@ public class AktoerRepositoryTests {
   public void TestInsertAktoerList() {
     List<Aktoer> aktoerer = generateAktoerList(20);
     aktoerRepository.insertOrUpdateAktoerer(aktoerer);
+    hendelseRepository.insertHendelser(aktoerer);
 
     List<Aktoer> savedAktoerer = aktoerJpaRepository.findAllByAktoerType(IdenttypeDTO.PERSONNUMMER.name(), Pageable.ofSize(100)).stream().toList();
+    List<Hendelse> savedHendelser = hendelseJpaRepository.findAll();
 
     assertEquals(20, savedAktoerer.size());
-    savedAktoerer.forEach(aktoer -> assertEquals(1, aktoer.getHendelser().size()));
+    assertEquals(20, savedHendelser.size());
+//    savedAktoerer.forEach(aktoer -> assertEquals(1, aktoer.getHendelser().size()));
 
     List<Aktoer> sublist = savedAktoerer.subList(0, 10);
 
     aktoerRepository.insertOrUpdateAktoerer(sublist);
+    hendelseRepository.insertHendelser(sublist);
 
     savedAktoerer = aktoerJpaRepository.findAllByAktoerType(IdenttypeDTO.PERSONNUMMER.name(), Pageable.ofSize(100)).stream().toList();
+    savedHendelser = hendelseJpaRepository.findAll();
     assertEquals(20, savedAktoerer.size());
+    assertEquals(30, savedHendelser.size());
 
-    List<Aktoer> savedUpdatedAktoerer = savedAktoerer.stream().filter(aktoer -> sublist.stream().filter(aktoer1 -> aktoer1.getAktoerId().equals(aktoer.getAktoerId())).findAny().orElse(null) != null).toList();
-    savedUpdatedAktoerer.forEach(aktoer -> assertEquals(2, aktoer.getHendelser().size()));
+    List<String> aktoerIds = sublist.stream().map(Aktoer::getAktoerId).toList();
+
+    List<Hendelse> aktoerHendelser = savedHendelser.stream().filter(hendelse -> aktoerIds.contains(hendelse.getAktoer().getAktoerId())).toList();
+
+    Map<String, List<Hendelse>> hendelseMap = new HashMap<>();
+    for(Hendelse hendelse : aktoerHendelser) {
+      if (!hendelseMap.containsKey(hendelse.getAktoer().getAktoerId())) {
+        hendelseMap.put(hendelse.getAktoer().getAktoerId(), new ArrayList<>());
+      }
+      List<Hendelse> hendelser = hendelseMap.get(hendelse.getAktoer().getAktoerId());
+      hendelser.add(hendelse);
+      hendelseMap.put(hendelse.getAktoer().getAktoerId(), hendelser);
+    }
+
+    sublist.forEach(aktoer -> {
+      assertEquals(2, hendelseMap.get(aktoer.getAktoerId()).size());
+    });
+
+//    List<Aktoer> savedUpdatedAktoerer = savedAktoerer.stream().filter(aktoer -> sublist.stream().filter(aktoer1 -> aktoer1.getAktoerId().equals(aktoer.getAktoerId())).findAny().orElse(null) != null).toList();
+//    savedUpdatedAktoerer.forEach(aktoer -> assertEquals(2, aktoer.getHendelser().size()));
   }
 
   private List<Aktoer> generateAktoerList(int numberOfAktoers) {

--- a/src/test/java/no/nav/bidrag/aktoerregister/repository/HendelseRepositoryMock.java
+++ b/src/test/java/no/nav/bidrag/aktoerregister/repository/HendelseRepositoryMock.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import no.nav.bidrag.aktoerregister.persistence.entities.Aktoer;
 import no.nav.bidrag.aktoerregister.persistence.entities.Hendelse;
 import no.nav.bidrag.aktoerregister.persistence.repository.HendelseRepository;
 
@@ -16,5 +17,16 @@ public record HendelseRepositoryMock(MockDB mockDB) implements HendelseRepositor
         .collect(Collectors.groupingBy(hendelse -> hendelse.getAktoer().getAktoerId()));
     return hendelseHashMap.values().stream().map(hendelses -> hendelses.stream().max(Comparator.comparingInt(Hendelse::getSekvensnummer)).orElse(null)
     ).toList();
+  }
+
+  @Override
+  public void insertHendelser(List<Aktoer> updatedAktoerer) {
+    List<Hendelse> hendelser = updatedAktoerer.stream().map(Hendelse::new).toList();
+    int max = mockDB.hendelseMap.keySet().stream().max(Integer::compareTo).orElse(0);
+    for(Hendelse hendelse : hendelser) {
+      max++;
+      hendelse.setSekvensnummer(max);
+      mockDB.hendelseMap.put(max, hendelse);
+    }
   }
 }


### PR DESCRIPTION
* Removed eager loading of `hendelser` when fetching `aktoerer` in batch.